### PR TITLE
Correct the config parameter - path to GCP credential file

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/config/gcloud/SecretManagerConfigProviderConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/config/gcloud/SecretManagerConfigProviderConfig.java
@@ -132,7 +132,7 @@ class SecretManagerConfigProviderConfig extends AbstractConfig {
 
       switch (credentialLocation) {
         case File:
-          String credentialsFile = getRequiredString(CREDENTIAL_LOCATION_CONFIG);
+          String credentialsFile = getRequiredString(CREDENTIAL_FILE_CONFIG);
           log.info("Loading credentials file '{}'", credentialsFile);
           try (InputStream inputStream = new FileInputStream(credentialsFile)) {
             result = GoogleCredentials.fromStream(inputStream);

--- a/src/main/java/com/github/jcustenborder/kafka/config/gcloud/SecretManagerFactoryImpl.java
+++ b/src/main/java/com/github/jcustenborder/kafka/config/gcloud/SecretManagerFactoryImpl.java
@@ -31,7 +31,7 @@ class SecretManagerFactoryImpl implements SecretManagerFactory {
       return SecretManagerServiceClient.create(settings);
     } catch (IOException ex) {
       ConfigException exception = new ConfigException("Exception during configuration");
-      exception.initCause(exception);
+      exception.initCause(ex);
       throw exception;
     }
   }


### PR DESCRIPTION
Hi! Currently it'snot possible to authenticate to GCP project using service account key with config like this:

`credential.location=File`
`credential.file=<path_to_json_key>`

I was getting FileNotFoundException from the plugin while reading the credential file. The problem appeared to be just some kind of a mistype. Could you please review the fix? 